### PR TITLE
update DisqusShortname to new spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Making use of [Carbon](https://carbondesignsystem.com/) for [Hugo](https://gohug
  - Support for Instana EUM (just set params > instanaKey)
  - Support for theme selection (params > cdstheme) - supports `white`, `g10`, `g90` and `g100` 
  - Support for preferred theme switching - specify lighttheme and darktheme in parameters from the options above
+ - Support for embedding pagefind search (set search to true in parameters)

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -8,7 +8,7 @@
     <!-- related posts with the same tags -->
     {{ $related := first 3 (where (where (where .Site.Pages.ByDate.Reverse ".Type" "==" "post") ".Params.tags" "intersect" .Params.tags) "Permalink" "!=" .Permalink) }}
 
-    {{ if and .Site.DisqusShortname (not .Params.disableComments) }}
+    {{ if and .Site.Config.Services.Disqus.Shortname (not .Params.disableComments) }}
 
         <h4 class="page-header">Comments</h4>
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -3,6 +3,7 @@
 </div>
 </main>
 {{ partial "side-nav.html" . }}
+<script src="/apic-cloud/multi-tenant/pagefind/pagefind-ui.js"></script>
 {{ if isset .Site.Params "darktheme" }}
 <script type="text/javascript">
     function setTheme(themeName) {
@@ -22,6 +23,15 @@
     }
     selectTheme()
     window.matchMedia('(prefers-color-scheme: dark)').onchange = selectTheme
+    
+    
+</script>
+{{ end }}
+{{ if .Site.Params.search }}
+<script>
+    window.addEventListener('DOMContentLoaded', (event) => {
+        new PagefindUI({ element: "#search", showSubResults: true, resetStyles: false, showImages: false });
+    });
 </script>
 {{ end }}
 </body>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -20,6 +20,7 @@
   <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/content-switcher.min.js"></script>
   <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/skip-to-content.min.js"></script>
   <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/tag.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/version/v2.27.2/search.min.js"></script>
   {{ if .Site.Params.favicon }}
   <link rel="icon" href="{{ .Site.Params.favicon | absURL }}">
   {{ end }}
@@ -64,6 +65,10 @@
         {{ end }}
     {{ end }}
   </cds-header-nav>
+  {{ if .Site.Params.search }}
+  <div id="search">
+  </div>
+  {{ end }}
 </cds-header>
 <div id="main-content" name="main-content" data-floating-menu-container="" class="cds--body cds-hugo-carbon--container" role="none">
 <main class="cds--content cds-hugo-carbon--ui-shell-content">

--- a/layouts/partials/side-nav.html
+++ b/layouts/partials/side-nav.html
@@ -1,5 +1,5 @@
 {{ if eq .Site.Params.sidenav "true" }}
-<cds-side-nav aria-label="Side navigation" role="navigation" collapse-mode="responsive" usage-mode="">
+<cds-side-nav aria-label="Side navigation" role="navigation" collapse-mode="responsive" usage-mode="" data-pagefind-ignore>
     {{ if eq .Site.Params.sidemenu "auto" }}
     {{ $currentPage := . }}
     {{ range .Site.Home.Pages}}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -198,3 +198,85 @@ line-height: 1rem;
 /* TextWhitespace */ .chroma .w { color: #6e7681 }
 
 .header {margin-top: 2rem;}
+
+#search {width: 60vw;}
+.pagefind-ui {
+  position:absolute;
+  top:0;
+  color: var(--cds-text-primary);
+}
+
+.pagefind-ui__drawer mark{
+  background-color: var(--cds-background-inverse-hover);
+}
+.pagefind-ui__form {
+  width: 20vw;
+  margin-left: 2em;
+}
+.pagefind-ui__search-clear {
+  position: absolute;
+  top: 3px;
+  right: 0;
+  height: 40px;
+  border: 1px;
+  background-color: var(--cds-button-secondary, #393939);
+  color: var(--cds-text-on-color, #ffffff);
+  padding: 0 15px;
+}
+.pagefind-ui input {
+    box-sizing: border-box;
+    margin: 3px 0 0 0;
+    padding: 0 1em;
+    vertical-align: baseline;
+    font-size: var(--cds-body-compact-01-font-size, .875rem);
+    font-weight: var(--cds-body-compact-01-font-weight, 400);
+    line-height: var(--cds-body-compact-01-line-height, 1.28572);
+    letter-spacing: var(--cds-body-compact-01-letter-spacing, .16px);
+    outline: transparent solid 1px;
+    outline-offset: -2px;
+    border: medium;
+    background-color: var(--cds-field);
+    block-size: var(--cds-layout-size-height-local);
+    border-block-end: 0px solid var(--cds-border-strong);
+    color: var(--cds-text-primary, #161616);
+    font-family: inherit;
+    inline-size: calc(100% - 45px);
+    height: var(--cds-layout-size-height-md, 2.5rem);
+}
+.pagefind-ui__drawer {
+max-height: 60vh;
+width: 33vw;
+overflow: scroll;
+box-shadow: 3px 3px 10px var(--cds-border-subtle);
+background: var(--cds-background-inverse);
+color: var(--cds-text-inverse)
+}
+.pagefind-ui__drawer p {
+  color: var(--cds-text-inverse)
+}
+li.pagefind-ui__result {
+  list-style: none;
+}
+.pagefind-ui__result-title {
+  color: var(--cds-text-inverse);
+}
+.pagefind-ui__result-link {
+  color: var(--cds-link-inverse);
+}
+.pagefind-ui__result-nested {
+  padding-left: 2em;
+}
+.pagefind-ui__result-excerpt { 
+color: var(--cds-text-inverse)
+}
+.pagefind-ui__result-nested .pagefind-ui__result-link {
+  color: var(--cds-link-inverse);
+}
+.pagefind-ui__result-nested .pagefind-ui__result-link:before {
+  content: "\2937 ";
+  top: 0;
+  right: calc(100% + .1em);
+}
+.pagefind-ui__result-excerpt {
+  font-size: var(--cds-body-compact-01-font-size);
+}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -208,6 +208,7 @@ line-height: 1rem;
 
 .pagefind-ui__drawer mark{
   background-color: var(--cds-background-inverse-hover);
+  color: var(--cds-text-inverse);
 }
 .pagefind-ui__form {
   width: 20vw;


### PR DESCRIPTION
Trying to resolve error in Hugo build:
```
ERROR deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.133.0. Use .Site.Config.Services.Disqus.Shortname instead.
```

after making this change locally, build proceeded without issue