### PR TITLE
Update disqus spec to new

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -8,7 +8,7 @@
     <!-- related posts with the same tags -->
     {{ $related := first 3 (where (where (where .Site.Pages.ByDate.Reverse ".Type" "==" "post") ".Params.tags" "intersect" .Params.tags) "Permalink" "!=" .Permalink) }}
 
-    {{ if and .Site.DisqusShortname (not .Params.disableComments) }}
+    {{ if and .Site.Config.Services.Disqus.Shortname (not .Params.disableComments) }}
 
         <h4 class="page-header">Comments</h4>
 


### PR DESCRIPTION
This should resolve hugo build error: 

```
ERROR deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.133.0. Use .Site.Config.Services.Disqus.Shortname instead.
```